### PR TITLE
Open graph images for debate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ conf/httpd.conf.deployed
 conf/crontab
 conf/crontab.deployed
 __pycache__/
+vendor/fonts

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ RUN apt-get update && apt-get install -y \
     binutils libgdal-dev gdal-bin libproj-dev git npm \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -sSL https://install.python-poetry.org | python -
+RUN mkdir -p /usr/local/share/fonts/truetype/merriweather \
+    && curl -L https://github.com/google/fonts/raw/refs/heads/main/ofl/merriweather/Merriweather%5Bopsz,wdth,wght%5D.ttf \
+    -o /usr/local/share/fonts/truetype/merriweather/Merriweather.ttf \
+    && fc-cache -f -v
 ENV PATH="/root/.local/bin:$PATH"
 WORKDIR $PYSETUP_PATH
 COPY poetry.loc[k] pyproject.toml ./

--- a/poetry.lock
+++ b/poetry.lock
@@ -1174,6 +1174,94 @@ psycopg = ">=3.0.10"
 sqlparse = ">=0.1.19"
 
 [[package]]
+name = "pillow"
+version = "11.1.0"
+description = "Python Imaging Library (Fork)"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pillow-11.1.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:e1abe69aca89514737465752b4bcaf8016de61b3be1397a8fc260ba33321b3a8"},
+    {file = "pillow-11.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c640e5a06869c75994624551f45e5506e4256562ead981cce820d5ab39ae2192"},
+    {file = "pillow-11.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a07dba04c5e22824816b2615ad7a7484432d7f540e6fa86af60d2de57b0fcee2"},
+    {file = "pillow-11.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e267b0ed063341f3e60acd25c05200df4193e15a4a5807075cd71225a2386e26"},
+    {file = "pillow-11.1.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:bd165131fd51697e22421d0e467997ad31621b74bfc0b75956608cb2906dda07"},
+    {file = "pillow-11.1.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:abc56501c3fd148d60659aae0af6ddc149660469082859fa7b066a298bde9482"},
+    {file = "pillow-11.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:54ce1c9a16a9561b6d6d8cb30089ab1e5eb66918cb47d457bd996ef34182922e"},
+    {file = "pillow-11.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:73ddde795ee9b06257dac5ad42fcb07f3b9b813f8c1f7f870f402f4dc54b5269"},
+    {file = "pillow-11.1.0-cp310-cp310-win32.whl", hash = "sha256:3a5fe20a7b66e8135d7fd617b13272626a28278d0e578c98720d9ba4b2439d49"},
+    {file = "pillow-11.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:b6123aa4a59d75f06e9dd3dac5bf8bc9aa383121bb3dd9a7a612e05eabc9961a"},
+    {file = "pillow-11.1.0-cp310-cp310-win_arm64.whl", hash = "sha256:a76da0a31da6fcae4210aa94fd779c65c75786bc9af06289cd1c184451ef7a65"},
+    {file = "pillow-11.1.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:e06695e0326d05b06833b40b7ef477e475d0b1ba3a6d27da1bb48c23209bf457"},
+    {file = "pillow-11.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:96f82000e12f23e4f29346e42702b6ed9a2f2fea34a740dd5ffffcc8c539eb35"},
+    {file = "pillow-11.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3cd561ded2cf2bbae44d4605837221b987c216cff94f49dfeed63488bb228d2"},
+    {file = "pillow-11.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f189805c8be5ca5add39e6f899e6ce2ed824e65fb45f3c28cb2841911da19070"},
+    {file = "pillow-11.1.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:dd0052e9db3474df30433f83a71b9b23bd9e4ef1de13d92df21a52c0303b8ab6"},
+    {file = "pillow-11.1.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:837060a8599b8f5d402e97197d4924f05a2e0d68756998345c829c33186217b1"},
+    {file = "pillow-11.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:aa8dd43daa836b9a8128dbe7d923423e5ad86f50a7a14dc688194b7be5c0dea2"},
+    {file = "pillow-11.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0a2f91f8a8b367e7a57c6e91cd25af510168091fb89ec5146003e424e1558a96"},
+    {file = "pillow-11.1.0-cp311-cp311-win32.whl", hash = "sha256:c12fc111ef090845de2bb15009372175d76ac99969bdf31e2ce9b42e4b8cd88f"},
+    {file = "pillow-11.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:fbd43429d0d7ed6533b25fc993861b8fd512c42d04514a0dd6337fb3ccf22761"},
+    {file = "pillow-11.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:f7955ecf5609dee9442cbface754f2c6e541d9e6eda87fad7f7a989b0bdb9d71"},
+    {file = "pillow-11.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2062ffb1d36544d42fcaa277b069c88b01bb7298f4efa06731a7fd6cc290b81a"},
+    {file = "pillow-11.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a85b653980faad27e88b141348707ceeef8a1186f75ecc600c395dcac19f385b"},
+    {file = "pillow-11.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9409c080586d1f683df3f184f20e36fb647f2e0bc3988094d4fd8c9f4eb1b3b3"},
+    {file = "pillow-11.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7fdadc077553621911f27ce206ffcbec7d3f8d7b50e0da39f10997e8e2bb7f6a"},
+    {file = "pillow-11.1.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:93a18841d09bcdd774dcdc308e4537e1f867b3dec059c131fde0327899734aa1"},
+    {file = "pillow-11.1.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:9aa9aeddeed452b2f616ff5507459e7bab436916ccb10961c4a382cd3e03f47f"},
+    {file = "pillow-11.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3cdcdb0b896e981678eee140d882b70092dac83ac1cdf6b3a60e2216a73f2b91"},
+    {file = "pillow-11.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:36ba10b9cb413e7c7dfa3e189aba252deee0602c86c309799da5a74009ac7a1c"},
+    {file = "pillow-11.1.0-cp312-cp312-win32.whl", hash = "sha256:cfd5cd998c2e36a862d0e27b2df63237e67273f2fc78f47445b14e73a810e7e6"},
+    {file = "pillow-11.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:a697cd8ba0383bba3d2d3ada02b34ed268cb548b369943cd349007730c92bddf"},
+    {file = "pillow-11.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:4dd43a78897793f60766563969442020e90eb7847463eca901e41ba186a7d4a5"},
+    {file = "pillow-11.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ae98e14432d458fc3de11a77ccb3ae65ddce70f730e7c76140653048c71bfcbc"},
+    {file = "pillow-11.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cc1331b6d5a6e144aeb5e626f4375f5b7ae9934ba620c0ac6b3e43d5e683a0f0"},
+    {file = "pillow-11.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:758e9d4ef15d3560214cddbc97b8ef3ef86ce04d62ddac17ad39ba87e89bd3b1"},
+    {file = "pillow-11.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b523466b1a31d0dcef7c5be1f20b942919b62fd6e9a9be199d035509cbefc0ec"},
+    {file = "pillow-11.1.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:9044b5e4f7083f209c4e35aa5dd54b1dd5b112b108648f5c902ad586d4f945c5"},
+    {file = "pillow-11.1.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3764d53e09cdedd91bee65c2527815d315c6b90d7b8b79759cc48d7bf5d4f114"},
+    {file = "pillow-11.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:31eba6bbdd27dde97b0174ddf0297d7a9c3a507a8a1480e1e60ef914fe23d352"},
+    {file = "pillow-11.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b5d658fbd9f0d6eea113aea286b21d3cd4d3fd978157cbf2447a6035916506d3"},
+    {file = "pillow-11.1.0-cp313-cp313-win32.whl", hash = "sha256:f86d3a7a9af5d826744fabf4afd15b9dfef44fe69a98541f666f66fbb8d3fef9"},
+    {file = "pillow-11.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:593c5fd6be85da83656b93ffcccc2312d2d149d251e98588b14fbc288fd8909c"},
+    {file = "pillow-11.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:11633d58b6ee5733bde153a8dafd25e505ea3d32e261accd388827ee987baf65"},
+    {file = "pillow-11.1.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:70ca5ef3b3b1c4a0812b5c63c57c23b63e53bc38e758b37a951e5bc466449861"},
+    {file = "pillow-11.1.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8000376f139d4d38d6851eb149b321a52bb8893a88dae8ee7d95840431977081"},
+    {file = "pillow-11.1.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ee85f0696a17dd28fbcfceb59f9510aa71934b483d1f5601d1030c3c8304f3c"},
+    {file = "pillow-11.1.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:dd0e081319328928531df7a0e63621caf67652c8464303fd102141b785ef9547"},
+    {file = "pillow-11.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e63e4e5081de46517099dc30abe418122f54531a6ae2ebc8680bcd7096860eab"},
+    {file = "pillow-11.1.0-cp313-cp313t-win32.whl", hash = "sha256:dda60aa465b861324e65a78c9f5cf0f4bc713e4309f83bc387be158b077963d9"},
+    {file = "pillow-11.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ad5db5781c774ab9a9b2c4302bbf0c1014960a0a7be63278d13ae6fdf88126fe"},
+    {file = "pillow-11.1.0-cp313-cp313t-win_arm64.whl", hash = "sha256:67cd427c68926108778a9005f2a04adbd5e67c442ed21d95389fe1d595458756"},
+    {file = "pillow-11.1.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:bf902d7413c82a1bfa08b06a070876132a5ae6b2388e2712aab3a7cbc02205c6"},
+    {file = "pillow-11.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c1eec9d950b6fe688edee07138993e54ee4ae634c51443cfb7c1e7613322718e"},
+    {file = "pillow-11.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e275ee4cb11c262bd108ab2081f750db2a1c0b8c12c1897f27b160c8bd57bbc"},
+    {file = "pillow-11.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4db853948ce4e718f2fc775b75c37ba2efb6aaea41a1a5fc57f0af59eee774b2"},
+    {file = "pillow-11.1.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:ab8a209b8485d3db694fa97a896d96dd6533d63c22829043fd9de627060beade"},
+    {file = "pillow-11.1.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:54251ef02a2309b5eec99d151ebf5c9904b77976c8abdcbce7891ed22df53884"},
+    {file = "pillow-11.1.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:5bb94705aea800051a743aa4874bb1397d4695fb0583ba5e425ee0328757f196"},
+    {file = "pillow-11.1.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89dbdb3e6e9594d512780a5a1c42801879628b38e3efc7038094430844e271d8"},
+    {file = "pillow-11.1.0-cp39-cp39-win32.whl", hash = "sha256:e5449ca63da169a2e6068dd0e2fcc8d91f9558aba89ff6d02121ca8ab11e79e5"},
+    {file = "pillow-11.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:3362c6ca227e65c54bf71a5f88b3d4565ff1bcbc63ae72c34b07bbb1cc59a43f"},
+    {file = "pillow-11.1.0-cp39-cp39-win_arm64.whl", hash = "sha256:b20be51b37a75cc54c2c55def3fa2c65bb94ba859dde241cd0a4fd302de5ae0a"},
+    {file = "pillow-11.1.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:8c730dc3a83e5ac137fbc92dfcfe1511ce3b2b5d7578315b63dbbb76f7f51d90"},
+    {file = "pillow-11.1.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:7d33d2fae0e8b170b6a6c57400e077412240f6f5bb2a342cf1ee512a787942bb"},
+    {file = "pillow-11.1.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a8d65b38173085f24bc07f8b6c505cbb7418009fa1a1fcb111b1f4961814a442"},
+    {file = "pillow-11.1.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:015c6e863faa4779251436db398ae75051469f7c903b043a48f078e437656f83"},
+    {file = "pillow-11.1.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d44ff19eea13ae4acdaaab0179fa68c0c6f2f45d66a4d8ec1eda7d6cecbcc15f"},
+    {file = "pillow-11.1.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d3d8da4a631471dfaf94c10c85f5277b1f8e42ac42bade1ac67da4b4a7359b73"},
+    {file = "pillow-11.1.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:4637b88343166249fe8aa94e7c4a62a180c4b3898283bb5d3d2fd5fe10d8e4e0"},
+    {file = "pillow-11.1.0.tar.gz", hash = "sha256:368da70808b36d73b4b390a8ffac11069f8a5c85f29eff1f1b01bcf3ef5b2a20"},
+]
+
+[package.extras]
+docs = ["furo", "olefile", "sphinx (>=8.1)", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxext-opengraph"]
+fpx = ["olefile"]
+mic = ["olefile"]
+tests = ["check-manifest", "coverage (>=7.4.2)", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout", "trove-classifiers (>=2024.10.12)"]
+typing = ["typing-extensions"]
+xmp = ["defusedxml"]
+
+[[package]]
 name = "platformdirs"
 version = "4.2.2"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
@@ -2321,4 +2409,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "2abb8043660b2041bfff4fd8b9903ec764bb576c0b44a134b34a1c32c331bba1"
+content-hash = "ad268f5919102a7a36d584deacb175c1a7015303d374d3d99b9295be108158ed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ django-ninja = "^1.3.0"
 markdown = "^3.7"
 bs4 = "^0.0.2"
 django-debug-toolbar = "^4.4.6"
+pillow = "^11.1.0"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.6.2"

--- a/tests/test_opengraph.py
+++ b/tests/test_opengraph.py
@@ -1,0 +1,29 @@
+from django.test import Client
+
+import pytest
+
+from votes.models import Agreement, Division
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def division_id():
+    return Division.objects.get(key="pw-2016-12-13-109-commons").id
+
+
+@pytest.fixture
+def agreement_id():
+    return Agreement.objects.get(key="a-commons-2024-12-19-b.564.3.2").id
+
+
+def test_division_image(client: Client, division_id: int):
+    response = client.get(f"/opengraph/division/{division_id}")
+    assert response.status_code == 200
+    assert response["Content-Type"] == "image/png"
+
+
+def test_agreement_image(client: Client, agreement_id: int):
+    response = client.get(f"/opengraph/agreement/{agreement_id}")
+    assert response.status_code == 200
+    assert response["Content-Type"] == "image/png"

--- a/votes/templates/votes/base.html
+++ b/votes/templates/votes/base.html
@@ -33,8 +33,13 @@
         <meta property="og:description"
             content="{{ meta_description|default:"Analysis and data on voting in the UK's Parliaments" }}">
             <meta property="og:type" content="website">
-            <meta property="og:image"
-                  content="https://{{ request.get_host }}{% static 'img/opengraph.png' %}">
+            {% if og_image %}
+                <meta property="og:image"
+                      content="https://{{ request.get_host }}{{ og_image }}">
+            {% else %}
+                <meta property="og:image"
+                      content="https://{{ request.get_host }}{% static 'img/opengraph.png' %}">
+            {% endif %}
             <meta property="og:image:type" content="image/png">
             <meta property="og:image:width" content="1200">
             <meta property="og:image:height" content="630">

--- a/votes/urls.py
+++ b/votes/urls.py
@@ -127,5 +127,15 @@ urlpatterns = [
     ),
     fast_path("help/{markdown_slug:slug}", views.MarkdownView, name="help"),
     fast_path("data", views.DataView, name="data"),
+    fast_path(
+        "opengraph/division/{division_id:int}",
+        views.DivisionOpenGraphImageView,
+        name="division_opengraph_image",
+    ),
+    fast_path(
+        "opengraph/agreement/{agreement_id:int}",
+        views.AgreementOpenGraphImageView,
+        name="agreement_opengraph_image",
+    ),
     path("", api.urls),
 ]

--- a/votes/views/opengraph.py
+++ b/votes/views/opengraph.py
@@ -1,0 +1,412 @@
+import html
+from pathlib import Path
+from typing import NamedTuple
+
+import pandas as pd
+from PIL import Image, ImageDraw, ImageFont
+
+from votes.models import Division, Membership
+
+IMAGE_WIDTH, IMAGE_HEIGHT = 1200, 627
+DOT_SIZE = 10
+GRID_SIZE = 5  # 5x5 grid
+GRID_SPACING = 15  # Space between grids
+GROUP_SPACING = 30  # Space between grid groups
+DOT_SPACING = 3  # Spacing between dots
+MARGIN = 40
+TOP_MARGIN = 25
+BACKGROUND_COLOR = "#f3f1eb"
+
+
+class ColourSettings(NamedTuple):
+    colour: str
+    border_colour: str = ""
+
+
+class TextDimensions(NamedTuple):
+    width: float
+    height: float
+
+
+colours = {
+    "ceidwadwyr": ColourSettings(colour="#166FD2"),
+    "conservative": ColourSettings(colour="#166FD2"),
+    "labour": ColourSettings(colour="#EE3224"),
+    "llafur": ColourSettings(colour="#EE3224"),
+    "labourco-operative": ColourSettings(colour="#EE3224"),
+    "labour-co-operative": ColourSettings(colour="#EE3224"),
+    "democratiaid-rhyddfrydol": ColourSettings(colour="#FFBB33"),
+    "liberal-democrat": ColourSettings(colour="#FFBB33"),
+    "scottish-national-party": ColourSettings(
+        colour="#FDF38E", border_colour="#7E7A47"
+    ),
+    "plaid-cymru": ColourSettings(colour="#E0861A"),
+    "green": ColourSettings(colour="#6AB023"),
+    "dup": ColourSettings(colour="#193264"),
+    "social-democratic-and-labour-party": ColourSettings(colour="#3C783C"),
+}
+
+
+def fetch_merriweather():
+    """
+    Ensure we have a local copy of the merriweather font
+    """
+    font_dest = Path("/usr/local/share/fonts/truetype/merriweather/Merriweather.ttf")
+    if not font_dest.exists():
+        raise ValueError("Merriweather font not found, please install it.")
+    return font_dest
+
+
+def simplify_votes_df(division: Division) -> pd.DataFrame:
+    division.votes_df()
+
+    relevant_memberships = Membership.objects.filter(
+        chamber=division.chamber,
+        start_date__lte=division.date,
+        end_date__gte=division.date,
+    ).prefetch_related("party", "person")
+    person_to_membership_map = {x.person_id: x for x in relevant_memberships}
+
+    data = [
+        {
+            "party": person_to_membership_map[v.person_id].party.slug,
+            "vote": v.vote_desc(),
+        }
+        for v in division.votes.all().prefetch_related("person")
+    ]
+
+    df = pd.DataFrame(data)
+
+    df["background_colour"] = df["party"].map(
+        lambda x: colours[x].colour if x in colours else "#000000"
+    )
+
+    # set the bordercolour to the same as the background colour if not defined
+    df["border_colour"] = df["party"].map(
+        lambda x: colours[x].border_colour if x in colours else "#000000"
+    )
+    df["border_colour"] = df.apply(
+        lambda x: (
+            x["background_colour"] if x["border_colour"] == "" else x["border_colour"]
+        ),
+        axis=1,
+    )
+
+    df = df.sort_values(
+        by=["party", "vote"],
+        ascending=[True, True],
+    )
+
+    return df
+
+
+def create_canvas(
+    width: int = IMAGE_WIDTH,
+    height: int = IMAGE_HEIGHT,
+    bg_color: str = BACKGROUND_COLOR,
+) -> Image.Image:
+    """Creates a blank canvas with the specified dimensions and background color."""
+    return Image.new("RGB", (width, height), bg_color)
+
+
+def get_font(font_path: Path, size: int) -> ImageFont.FreeTypeFont:
+    """Returns a font object with the specified path and size."""
+    return ImageFont.truetype(font_path, size)
+
+
+def get_text_dimensions(font: ImageFont.FreeTypeFont, text: str) -> TextDimensions:
+    """Gets the width and height of text using a specific font."""
+    bbox = font.getbbox(text)
+    return TextDimensions(width=bbox[2] - bbox[0], height=bbox[3] - bbox[1])
+
+
+def draw_centered_text(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    y: int,
+    font: ImageFont.FreeTypeFont,
+    color: str = "black",
+    width: int = IMAGE_WIDTH,
+) -> float:
+    """Draws text centered horizontally at the specified y position."""
+    dimensions = get_text_dimensions(font=font, text=text)
+    x_position = (width - dimensions.width) // 2
+    draw.text((x_position, y), text, fill=color, font=font)
+    return dimensions.width
+
+
+def fit_text_to_width(
+    font_path: Path, font_size: int, text: str, max_width: int
+) -> ImageFont.FreeTypeFont:
+    """Returns a font that will render the text within the specified width."""
+    font = get_font(font_path=font_path, size=font_size)
+    dimensions = get_text_dimensions(font=font, text=text)
+
+    while dimensions.width > max_width:
+        font_size -= 1
+        font = get_font(font_path=font_path, size=font_size)
+        dimensions = get_text_dimensions(font=font, text=text)
+
+    return font
+
+
+def draw_dot_grid(
+    draw: ImageDraw.ImageDraw,
+    group: pd.DataFrame,
+    vote_start_y: float,
+    grids_per_row: int,
+) -> float:
+    """Draws a grid of dots for a vote type."""
+    dots_per_full_grid = GRID_SIZE * GRID_SIZE
+    max_y_this_section = vote_start_y
+
+    for dot_index, (_, row) in enumerate(group.iterrows()):
+        # Calculate the current grid
+        current_grid = dot_index // dots_per_full_grid
+
+        # Calculate the grid's row and column
+        grid_row = current_grid // grids_per_row
+        grid_col = current_grid % grids_per_row
+
+        # Calculate position within the grid
+        in_grid_index = dot_index % dots_per_full_grid
+        in_grid_row = in_grid_index // GRID_SIZE
+        in_grid_col = in_grid_index % GRID_SIZE
+
+        # Calculate the actual x and y coordinates for this dot - left aligned at MARGIN
+        single_grid_width = GRID_SIZE * (DOT_SIZE + DOT_SPACING) - DOT_SPACING
+        x = (
+            MARGIN
+            + grid_col * (single_grid_width + GRID_SPACING)
+            + in_grid_col * (DOT_SIZE + DOT_SPACING)
+        )
+        y = (
+            vote_start_y
+            + grid_row * (GRID_SIZE * (DOT_SIZE + DOT_SPACING) + GRID_SPACING)
+            + in_grid_row * (DOT_SIZE + DOT_SPACING)
+        )
+
+        # Draw the dot
+        background_colour = row["background_colour"]
+        border_colour = row["border_colour"]
+        draw.ellipse(
+            [x, y, x + DOT_SIZE, y + DOT_SIZE],
+            fill=background_colour,
+            outline=border_colour,
+            width=1,  # Ensure the border is smooth
+        )
+
+        # Keep track of the maximum y-coordinate used
+        max_y_this_dot = y + DOT_SIZE
+        if max_y_this_dot > max_y_this_section:
+            max_y_this_section = max_y_this_dot
+
+    return max_y_this_section
+
+
+def draw_footer(draw: ImageDraw.ImageDraw, font_path: Path) -> None:
+    """Draw the TheyWorkForYou Votes footer with 'You' bolded."""
+    footer_text_part1 = "TheyWorkFor"
+    footer_text_part2 = "You"
+    footer_text_part3 = " Votes"
+    footer_font = get_font(font_path=font_path, size=27)
+    footer_bold_font = get_font(font_path=font_path, size=27)
+
+    # Get dimensions for each part
+    part1_dims = get_text_dimensions(font=footer_font, text=footer_text_part1)
+    part2_dims = get_text_dimensions(font=footer_bold_font, text=footer_text_part2)
+    part3_dims = get_text_dimensions(font=footer_font, text=footer_text_part3)
+
+    # Calculate total width and positions
+    total_width = part1_dims.width + part2_dims.width + part3_dims.width
+    footer_x = IMAGE_WIDTH - total_width - MARGIN
+    footer_y = IMAGE_HEIGHT - part1_dims.height - MARGIN
+
+    # Draw each part
+    draw.text((footer_x, footer_y), footer_text_part1, fill="black", font=footer_font)
+    draw.text(
+        (footer_x + part1_dims.width, footer_y),
+        footer_text_part2,
+        fill="black",
+        font=footer_bold_font,
+    )
+    draw.text(
+        (footer_x + part1_dims.width + part2_dims.width, footer_y),
+        footer_text_part3,
+        fill="black",
+        font=footer_font,
+    )
+
+
+def draw_vote_image(division: Division) -> Image.Image:
+    """
+    Main function to create the vote visualization
+    """
+    # Setup
+    df = simplify_votes_df(division)
+    merriweather_font_path = fetch_merriweather()
+    image = create_canvas()
+    draw = ImageDraw.Draw(image)
+
+    # Draw division title
+    division_name = html.unescape(division.safe_decision_name())
+    max_text_width = int(IMAGE_WIDTH * 0.95)
+    title_font = fit_text_to_width(
+        font_path=merriweather_font_path,
+        font_size=60,
+        text=division_name,
+        max_width=max_text_width,
+    )
+    dimensions = get_text_dimensions(font=title_font, text=division_name)
+
+    # Draw centered title
+    x_position = (IMAGE_WIDTH - dimensions.width) // 2
+    draw.text((x_position, TOP_MARGIN), division_name, fill="black", font=title_font)
+
+    # Draw division date
+    division_date = division.date.strftime(
+        "%d %B %Y"
+    )  # British format: "10 April 2025"
+    date_dimensions = get_text_dimensions(font=title_font, text=division_date)
+    date_y_position = TOP_MARGIN + dimensions.height + 20
+    date_x_position = (IMAGE_WIDTH - date_dimensions.width) // 2
+    draw.text(
+        (date_x_position, date_y_position), division_date, fill="black", font=title_font
+    )
+
+    # Start position for vote sections
+    section_y_start = date_y_position + date_dimensions.height + 35
+    max_y_used = section_y_start
+
+    # Create label font
+    label_font = get_font(font_path=merriweather_font_path, size=30)
+
+    # Calculate grid layout
+    single_grid_width = GRID_SIZE * (DOT_SIZE + DOT_SPACING) - DOT_SPACING
+    available_width = IMAGE_WIDTH - 2 * MARGIN
+    single_grid_with_spacing = single_grid_width + GRID_SPACING
+    grids_per_row = max(1, min(10, available_width // single_grid_with_spacing))
+
+    # Filter votes by type
+
+    absent_count = len(df[df["vote"] == "Absent"])
+    aye_count = len(df[df["vote"] == "Aye"])
+    no_count = len(df[df["vote"] == "No"])
+
+    # Check if we should include "Absent" votes
+    # We can include absent dots if each of Aye and No take up one line
+    # We can include just the total if aye + no is only 3 lines between them
+    include_absent_dots = aye_count <= 250 and no_count <= 250 and absent_count <= 250
+    include_absent_title = (aye_count + no_count) < 250 * 3
+
+    # Prepare the dataframe for display
+    if include_absent_dots:
+        # Create a new DataFrame with Aye, No and Absent votes
+        display_dots_for = ["Aye", "No", "Absent"]
+    else:
+        display_dots_for = ["Aye", "No"]
+
+    if include_absent_title:
+        vote_types_to_include = ["Aye", "No", "Absent"]
+    else:
+        vote_types_to_include = ["Aye", "No"]
+
+    filtered_df = df[df["vote"].isin(vote_types_to_include)]
+
+    # Group by vote type
+    votes_by_type = filtered_df.groupby("vote")
+
+    # Define the order of vote types
+    vote_order = ["Aye", "No", "Absent"]
+
+    # Define which vote types should display dots
+
+    # Process vote types in specific order
+    for vote_type in vote_order:
+        # Skip if this vote type is not in the filtered data
+        if vote_type not in votes_by_type.groups:
+            continue
+
+        # Get the group for this vote type
+        group = votes_by_type.get_group(vote_type)
+        vote_count = len(group)
+        member_plural = division.chamber.member_plural
+        vote_label = f"{vote_type}: {vote_count} {member_plural}"
+
+        # Draw vote label
+        label_width, label_height = get_text_dimensions(
+            font=label_font, text=vote_label
+        )
+        draw.text((MARGIN, max_y_used), vote_label, fill="black", font=label_font)
+        vote_start_y = max_y_used + label_height + 15
+
+        # Only draw dots grid for displayed types
+        if vote_type in display_dots_for:
+            # Draw dots for this vote type
+            max_y_this_section = draw_dot_grid(
+                draw=draw,
+                group=group,
+                vote_start_y=vote_start_y,
+                grids_per_row=grids_per_row,
+            )
+
+            # Update the max_y_used to include the height of the grid
+            max_y_used = max_y_this_section + GROUP_SPACING
+        else:
+            # For Absent and Abstain, just update max_y_used past the label
+            max_y_used = vote_start_y + GROUP_SPACING
+
+    # Draw footer with "You" bolded
+    draw_footer(draw=draw, font_path=merriweather_font_path)
+
+    return image
+
+
+def draw_custom_image(header: str, subheader: str) -> Image.Image:
+    """
+    Create an image with custom header and subheader text, centered vertically and horizontally
+    """
+    merriweather_font_path = fetch_merriweather()
+    image = create_canvas()
+    draw = ImageDraw.Draw(image)
+
+    # Calculate maximum text width
+    max_text_width = int(IMAGE_WIDTH * 0.95)
+
+    # Fit header text to width and get dimensions
+    header_font = fit_text_to_width(
+        font_path=merriweather_font_path,
+        font_size=60,
+        text=header,
+        max_width=max_text_width,
+    )
+    header_dims = get_text_dimensions(font=header_font, text=header)
+
+    # Fit subheader text to width and get dimensions
+    subheader_font = fit_text_to_width(
+        font_path=merriweather_font_path,
+        font_size=60,
+        text=subheader,
+        max_width=max_text_width,
+    )
+    subheader_dims = get_text_dimensions(font=subheader_font, text=subheader)
+
+    # Calculate total height of header, subheader, and spacing
+    total_text_height = header_dims.height + subheader_dims.height + 20
+
+    # Calculate starting y position to center the text vertically
+    start_y = (IMAGE_HEIGHT - total_text_height) // 2
+
+    # Draw header centered horizontally
+    header_x = (IMAGE_WIDTH - header_dims.width) // 2
+    draw.text((header_x, start_y), header, fill="black", font=header_font)
+
+    # Draw subheader centered horizontally below header
+    subheader_x = (IMAGE_WIDTH - subheader_dims.width) // 2
+    subheader_y = start_y + header_dims.height + 20
+    draw.text((subheader_x, subheader_y), subheader, fill="black", font=subheader_font)
+
+    # Draw footer with "You" bolded
+    draw_footer(draw=draw, font_path=merriweather_font_path)
+
+    return image


### PR DESCRIPTION
Paired with https://github.com/mysociety/theyworkforyou/pull/1874  - this adds dynamic open graph images for divisions and agreements. 

This brings the Voting Dots into the graph - with a set of rules trying to avoid overflows (will show/not show absent depending on how big other rows are).

e.g. here is a Commons division:

![image](https://github.com/user-attachments/assets/85e63c22-85b5-437d-b3b1-c96c50df78db)

And a lords division (obviously this gets less useful as titles get longer - might want a fall back logic for titles over a certain size (Chamber, Date, Division No?)

![image](https://github.com/user-attachments/assets/bfcc3921-ec81-44b8-83f4-8139a5962089)

Here is the much more basic version for agreements. In the short/long run this could converge with the template being used in twfy. Also just moving it down the page a bit would help.

![image](https://github.com/user-attachments/assets/55983707-bbcb-4b05-969a-110b362bdb11)
