### PR TITLE
Updated assisted dying policy

### DIFF
--- a/data/policies/6732.yml
+++ b/data/policies/6732.yml
@@ -32,6 +32,13 @@ division_links:
     date: 2024-11-29
     division_number: 51
   alignment: agree
+  strength: weak
+  notes: ''
+- decision:
+    chamber_slug: commons
+    date: 2025-06-20
+    division_number: 245
+  alignment: agree
   strength: strong
   notes: ''
 agreement_links: []


### PR DESCRIPTION
- Downgrade second reading in favour of third reading.

This is avoiding an incorrect measure for MPs who changed between the two - and also avoiding a 'voted a mixture of for and against' - which is true, but the final vote is the one that matters more per bill. 